### PR TITLE
feat: Enhance proxy input with protocol hint and auto-conversion

### DIFF
--- a/src/renderer/i18n/locales/en-US.json
+++ b/src/renderer/i18n/locales/en-US.json
@@ -43,6 +43,7 @@
     "personalAuth": "Login with Google",
     "proxyConfig": "Proxy",
     "geminiBaseUrl": "Gemini API Base URL",
+    "proxyHttpOnly": "Only http/https protocols are supported",
     "tempDir": "Temporary Directory",
     "language": "Language"
   },

--- a/src/renderer/i18n/locales/zh-CN.json
+++ b/src/renderer/i18n/locales/zh-CN.json
@@ -43,6 +43,7 @@
     "personalAuth": "Google帐号登录",
     "proxyConfig": "代理",
     "geminiBaseUrl": "Gemini API 基础URL",
+    "proxyHttpOnly": "仅支持 http/https 协议",
     "tempDir": "临时目录",
     "language": "语言"
   },

--- a/src/renderer/panel/geminsettings.tsx
+++ b/src/renderer/panel/geminsettings.tsx
@@ -117,7 +117,14 @@ const GeminiSettings: React.FC<{
         </Form.Item>
       )}
       <Form.Item label={t("settings.proxyConfig")} field="proxy">
-        <Input></Input>
+        <Input
+          placeholder={`${t("settings.proxyHttpOnly")}: http://127.0.0.1:7890`}
+          onChange={(value) => {
+            if (value.startsWith("socks5://")) {
+              form.setFieldValue("proxy", value.replace("socks5://", "http://"));
+            }
+          }}
+        ></Input>
       </Form.Item>
       <Form.Item label={t("settings.tempDir")} field="tempDir">
         {(props) => (


### PR DESCRIPTION
# 优化设置项交互
背景：
主要为了解决用户仅有安装产物，没有github帮助文档下，填写proxy，如果使用了socks类型，导致 llm无法正确使用的问题

解决方案：
设置项增加一些提示和交互(增加 hint提示，同时如果用户填写了socks类型，会自动改为 http开头)

<img width="2000" height="1200" alt="image" src="https://github.com/user-attachments/assets/4abd1ed3-6f38-4793-9a08-1597f2b4f1c0" />

